### PR TITLE
security: TanStack CVE-2026-45321 audit + supply chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/bzhub_web/bzhub_web"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,23 @@
+name: Security Audit
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bzhub_web/bzhub_web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: bzhub_web/bzhub_web/package-lock.json
+      - run: npm ci
+      - run: npm audit --audit-level=high

--- a/bzhub_web/bzhub_web/.npmrc
+++ b/bzhub_web/bzhub_web/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/bzhub_web/bzhub_web/package.json
+++ b/bzhub_web/bzhub_web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "audit": "npm audit"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.0.4",

--- a/bzhub_web/bzhub_web/vercel.json
+++ b/bzhub_web/bzhub_web/vercel.json
@@ -2,5 +2,5 @@
   "framework": "nextjs",
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
-  "installCommand": "npm ci"
+  "installCommand": "npm ci && npm audit --audit-level=high"
 }


### PR DESCRIPTION
## Summary\n\nAudited all dependencies for exposure to the Mini Shai-Hulud supply chain attack (CVE-2026-45321, GHSA-g7cv-rxg3-hmpx) that compromised 84 versions across 42 `@tanstack/*` packages on 2026-05-11.\n\n**Result: NOT AFFECTED.** No `@tanstack/*` packages found in direct or transitive dependencies.\n\n## Changes\n\n- `bzhub_web/bzhub_web/package.json`: added `npm run audit` script\n- `.github/dependabot.yml`: daily Dependabot checks for new CVEs\n- `.github/workflows/audit.yml`: CI gate — `npm audit --audit-level=high` on every push/PR\n- `bzhub_web/bzhub_web/vercel.json`: upgraded installCommand from `npm ci` to `npm ci && npm audit --audit-level=high`\n- `bzhub_web/bzhub_web/.npmrc`: `save-exact=true` to pin exact versions on future installs

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1N8Aw9Z1CEEE6iWeUEgrT)_